### PR TITLE
Integrate GPT chat with Bitrix for lead creation

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@
 #  BizPartner-AI · FastAPI + OpenAI Assistants  (рабочая «базовая» версия)
 # ────────────────────────────────────────────────────────────────────────────
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from pydantic import BaseModel
 from openai import OpenAI
 import os, time, json
@@ -182,4 +182,4 @@ async def chat(req: ChatRequest, request: Request):
 async def chat_options(request: Request):
     origin  = request.headers.get("origin", "")
     headers = cors_headers(origin) | {"Access-Control-Max-Age": "86400"}
-    return JSONResponse({}, status_code=204, headers=headers)
+    return Response(status_code=204, headers=headers)

--- a/main.py
+++ b/main.py
@@ -23,14 +23,27 @@ ALLOWED_ORIGINS = {
     "http://localhost:3000",     "http://localhost:5173",
     "http://127.0.0.1:3000",     "http://127.0.0.1:5173",
 }
+ALLOWED_SUFFIXES = (
+    ".lovable.dev", ".lovable.io", ".lovable.app",
+    ".bizpartner.pl",
+)
+
+def _is_allowed_origin(origin: str) -> bool:
+    if not origin:
+        return False
+    o = origin.lower()
+    if o in ALLOWED_ORIGINS:
+        return True
+    return any(o.endswith(suffix) for suffix in ALLOWED_SUFFIXES)
 
 def cors_headers(origin: str) -> dict:
-    allow = origin if origin in ALLOWED_ORIGINS else "*"
+    allow_origin = origin if _is_allowed_origin(origin) else "*"
     return {
-        "Access-Control-Allow-Origin":      allow,
+        "Access-Control-Allow-Origin":      allow_origin,
         "Access-Control-Allow-Methods":     "POST, OPTIONS",
         "Access-Control-Allow-Headers":     "Content-Type, Authorization",
-        "Access-Control-Allow-Credentials": "true" if allow != "*" else "false",
+        "Access-Control-Allow-Credentials": "true" if allow_origin != "*" else "false",
+        "Vary": "Origin",
     }
 
 # ── In-memory :  lead_id ↔ thread_id ───────────────────────────────────────

--- a/main.py
+++ b/main.py
@@ -40,7 +40,12 @@ lead_threads: dict[str, str] = {}
 def _bitrix_call(method: str, payload: dict) -> dict:
     if not BITRIX_WEBHOOK_URL:
         raise RuntimeError("Bitrix24 webhook URL is not configured. Set BITRIX_WEBHOOK_URL env var.")
-    url = f"{BITRIX_WEBHOOK_URL.rstrip('/')}/{method}.json"
+    base = BITRIX_WEBHOOK_URL.rstrip('/')
+    # Accept both base webhook URL and a full method endpoint that already ends with .json
+    if base.endswith('.json'):
+        url = base
+    else:
+        url = f"{base}/{method}.json"
     resp = requests.post(url, json=payload, timeout=15)
     resp.raise_for_status()
     data = resp.json()

--- a/main.py
+++ b/main.py
@@ -5,13 +5,15 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from openai import OpenAI
-import os, time
+import os, time, json
+import requests
 
 app = FastAPI()
 
 # ── OpenAI ────────────────────────────────────────────────────────────────
 client       = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 ASSISTANT_ID = os.getenv("ASSISTANT_ID")            # Railway → Variables
+BITRIX_WEBHOOK_URL = os.getenv("BITRIX_WEBHOOK_URL") or os.getenv("BITRIX_WEBHOOK")
 
 # ── CORS ──────────────────────────────────────────────────────────────────
 ALLOWED_ORIGINS = {
@@ -33,6 +35,51 @@ def cors_headers(origin: str) -> dict:
 
 # ── In-memory :  lead_id ↔ thread_id ───────────────────────────────────────
 lead_threads: dict[str, str] = {}
+
+# ── Bitrix24 helpers ───────────────────────────────────────────────────────
+def _bitrix_call(method: str, payload: dict) -> dict:
+    if not BITRIX_WEBHOOK_URL:
+        raise RuntimeError("Bitrix24 webhook URL is not configured. Set BITRIX_WEBHOOK_URL env var.")
+    url = f"{BITRIX_WEBHOOK_URL.rstrip('/')}/{method}.json"
+    resp = requests.post(url, json=payload, timeout=15)
+    resp.raise_for_status()
+    data = resp.json()
+    if isinstance(data, dict) and data.get("error"):
+        raise RuntimeError(f"Bitrix24 error: {data.get('error_description') or data.get('error')}")
+    return data.get("result", data)
+
+def create_bitrix_lead(args: dict) -> int:
+    title = args.get("title") or args.get("deal_title") or "Website Chat Lead"
+    first_name = args.get("first_name") or args.get("name") or ""
+    last_name = args.get("last_name") or args.get("surname") or ""
+    phone = args.get("phone") or args.get("phone_number")
+    email = args.get("email")
+    comments = (
+        args.get("comment") or args.get("comments") or args.get("note") or args.get("notes") or ""
+    )
+    source_id = args.get("source_id") or "WEB"
+    assigned_by_id = args.get("assigned_by_id")
+
+    fields = {
+        "TITLE": title,
+        "NAME": first_name,
+        "LAST_NAME": last_name,
+        "COMMENTS": comments,
+        "SOURCE_ID": source_id,
+        "OPENED": "Y",
+    }
+    if phone:
+        fields["PHONE"] = [{"VALUE": str(phone), "TYPE": "WORK"}]
+    if email:
+        fields["EMAIL"] = [{"VALUE": str(email), "TYPE": "WORK"}]
+    if assigned_by_id:
+        fields["ASSIGNED_BY_ID"] = assigned_by_id
+
+    result = _bitrix_call("crm.lead.add", {"fields": fields, "params": {"REGISTER_SONET_EVENT": "Y"}})
+    if isinstance(result, int):
+        return result
+    # sometimes Bitrix returns {"result": <id>} handled in _bitrix_call, but keep a safeguard
+    return int(result)
 
 # ── Модель входящего запроса ──────────────────────────────────────────────
 class ChatRequest(BaseModel):
@@ -60,21 +107,52 @@ async def chat(req: ChatRequest, request: Request):
             content=req.message
         )
 
-        # 3. запуск ассистента
+        # 3. запуск ассистента и обработка tool calls
         run = client.beta.threads.runs.create(
             thread_id=thread_id,
             assistant_id=ASSISTANT_ID
         )
 
-        # 4. ожидание завершения
+        last_lead_id: int | None = None
         while True:
             run_status = client.beta.threads.runs.retrieve(
                 run_id=run.id,
                 thread_id=thread_id
             )
+
+            if run_status.status == "requires_action":
+                tool_calls = run_status.required_action.submit_tool_outputs.tool_calls
+                tool_outputs = []
+                for tool_call in tool_calls:
+                    fn_name = tool_call.function.name
+                    try:
+                        fn_args = json.loads(tool_call.function.arguments or "{}")
+                    except Exception:
+                        fn_args = {}
+
+                    if fn_name in {"create_bitrix_lead", "crm_create_lead", "create_lead"}:
+                        lead_id = create_bitrix_lead(fn_args)
+                        last_lead_id = lead_id
+                        tool_outputs.append({
+                            "tool_call_id": tool_call.id,
+                            "output": json.dumps({"ok": True, "lead_id": lead_id})
+                        })
+                    else:
+                        tool_outputs.append({
+                            "tool_call_id": tool_call.id,
+                            "output": json.dumps({"ok": False, "error": f"unknown function: {fn_name}"})
+                        })
+
+                client.beta.threads.runs.submit_tool_outputs(
+                    thread_id=thread_id,
+                    run_id=run_status.id,
+                    tool_outputs=tool_outputs
+                )
+                continue
+
             if run_status.status == "completed":
                 break
-            if run_status.status in {"failed", "cancelled"}:
+            if run_status.status in {"failed", "cancelled", "expired"}:
                 raise RuntimeError(f"Run {run.id} ended with {run_status.status}")
             time.sleep(1)
 
@@ -82,7 +160,10 @@ async def chat(req: ChatRequest, request: Request):
         messages = client.beta.threads.messages.list(thread_id, order="desc")
         reply = messages.data[0].content[0].text.value
 
-        return JSONResponse({"reply": reply}, headers=headers)
+        resp = {"reply": reply}
+        if last_lead_id is not None:
+            resp["lead_id"] = last_lead_id
+        return JSONResponse(resp, headers=headers)
 
     except Exception as e:
         return JSONResponse(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 openai>=1.14
+requests


### PR DESCRIPTION
Integrate Bitrix24 lead creation via webhook, enabling the OpenAI Assistant to create leads from chat conversations.

The `main.py` now handles OpenAI Assistant tool calls, specifically for `create_bitrix_lead`, and returns the created `lead_id` to the frontend for thread continuity.

---
<a href="https://cursor.com/background-agent?bcId=bc-6316bdc2-a19f-4158-82aa-e173ada32341">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6316bdc2-a19f-4158-82aa-e173ada32341">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

